### PR TITLE
Move geopandas and matplotlib to extra deps. Refs #22

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,8 +25,6 @@ classifiers = [
 ]
 dependencies = [
     "geojson==3.1.0",
-    "geopandas==0.14.3",
-    "matplotlib==3.8.4",
     "requests==2.31.0",
     "shapely==2.0.4",
 ]
@@ -38,6 +36,8 @@ Issues = "https://github.com/OnroerendErfgoed/brdr/issues"
 [project.optional-dependencies]
 dev = [
     "black==24.4.0",
+    "geopandas==0.14.3",
+    "matplotlib==3.8.4",
     "hatchling==1.24.2",
     "pip-tools==7.4.1",
     "pytest-cov==5.0.0",

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -28,6 +28,8 @@ coverage==7.4.4
     # via pytest-cov
 cycler==0.12.1
     # via matplotlib
+exceptiongroup==1.2.1
+    # via pytest
 fiona==1.9.6
     # via geopandas
 fonttools==4.51.0
@@ -114,12 +116,24 @@ six==1.16.0
     #   python-dateutil
 toml==0.10.2
     # via brdr (pyproject.toml)
+tomli==2.0.1
+    # via
+    #   black
+    #   build
+    #   coverage
+    #   hatchling
+    #   mypy
+    #   pip-tools
+    #   pyproject-hooks
+    #   pytest
 trove-classifiers==2024.5.22
     # via hatchling
 types-requests==2.31.0.20240406
     # via brdr (pyproject.toml)
 typing-extensions==4.11.0
-    # via mypy
+    # via
+    #   black
+    #   mypy
 tzdata==2024.1
     # via pandas
 urllib3==2.2.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,74 +1,16 @@
-attrs==23.2.0
-    # via fiona
 certifi==2024.2.2
-    # via
-    #   fiona
-    #   pyproj
-    #   requests
+    # via requests
 charset-normalizer==3.3.2
     # via requests
-click==8.1.7
-    # via
-    #   click-plugins
-    #   cligj
-    #   fiona
-click-plugins==1.1.1
-    # via fiona
-cligj==0.7.2
-    # via fiona
-contourpy==1.2.1
-    # via matplotlib
-cycler==0.12.1
-    # via matplotlib
-fiona==1.9.6
-    # via geopandas
-fonttools==4.51.0
-    # via matplotlib
 geojson==3.1.0
-    # via brdr (pyproject.toml)
-geopandas==0.14.3
     # via brdr (pyproject.toml)
 idna==3.7
     # via requests
-kiwisolver==1.4.5
-    # via matplotlib
-matplotlib==3.8.4
-    # via brdr (pyproject.toml)
 numpy==1.26.4
-    # via
-    #   contourpy
-    #   matplotlib
-    #   pandas
-    #   shapely
-packaging==24.0
-    # via
-    #   geopandas
-    #   matplotlib
-pandas==2.2.2
-    # via geopandas
-pillow==10.3.0
-    # via matplotlib
-pyparsing==3.1.2
-    # via matplotlib
-pyproj==3.6.1
-    # via geopandas
-python-dateutil==2.9.0.post0
-    # via
-    #   matplotlib
-    #   pandas
-pytz==2024.1
-    # via pandas
+    # via shapely
 requests==2.31.0
     # via brdr (pyproject.toml)
 shapely==2.0.4
-    # via
-    #   brdr (pyproject.toml)
-    #   geopandas
-six==1.16.0
-    # via
-    #   fiona
-    #   python-dateutil
-tzdata==2024.1
-    # via pandas
+    # via brdr (pyproject.toml)
 urllib3==2.2.1
     # via requests


### PR DESCRIPTION
Since geopandas and matplotlib are only needed for the examples, moved them to the dev dependencies. Is this ok, or do we need an extra key in the pyproject.toml file for them? 